### PR TITLE
feat(Feeds/Toggles): Added additional buttons to toggle functinality, shortcut to Feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -111,14 +111,36 @@ autoReloadAfterIdle()
 
 
 // Some other styles
-GM_addStyle(`
+// GM_addStyle(`
 
-    /* remove install app toast */
-    div[data-comp-id~="22222"]:has([data-action-id~="32764"]){
-      display: none !important;
-    }
+//     /* remove install app toast */
+//     div[data-comp-id~="22222"]:has([data-action-id~="32764"]){
+//       display: none !important;
+//     }
 
-`)
+// `)
+
+// New Stuff
+// Button to Feeds
+const fillerElm = document.querySelector('.filler');
+if (fillerElm) {
+  const arbitraryOffset = 138;
+  const leftPos = window.screen.width - arbitraryOffset;
+  fillerElm.insertAdjacentHTML('afterend',`
+    <div id="feedsBtn"
+         style="z-index: 1;position: absolute;left: ${leftPos}px; pointer-events: all;">
+      <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
+        <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yB/r/Bc4BAjXDBat.png" class="img contain" style="filter: grayscale(1);">
+      </div>
+    </div>`);
+
+  document.getElementById('feedsBtn').addEventListener('click', function() {
+    document.querySelector('[aria-label="Facebook Menu"]').click();
+    window.setTimeout(function() {
+      document.querySelector('[aria-label="Feeds"]').click();
+    }, 500);
+  });
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////                   Labels           ////////////////////////

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -128,7 +128,7 @@ const tryAddFeedsButton = () => {
     // This is really flakey, and it keeps failing
     // TODO: Rewrite as an inclusion instead of excluding everything in the world
     // FB is still largely an SPA and pushes to history infrequently
-    const onInnerScreen = ['Feeds', 'Replies', 'Review posts and tags', 'People who reacted', 'Messages'].includes(innerScreenText);
+    const onInnerScreen = ['Feeds', 'Replies', 'Review posts and tags', 'People who reacted', 'Edit Post', 'Privacy'].includes(innerScreenText);
     if (fillerElm && !document.getElementById('feedsBtn') && !onInnerScreen) {
         const arbitraryOffset = 138;
         const leftPos = window.screen.width - arbitraryOffset;

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -124,8 +124,9 @@ autoReloadAfterIdle()
 const tryAddFeedsButton = () => {
     const fillerElm = document.querySelector('.filler');
     // TODO: Ensure localized
-    const alreadyOnFeedsScreen = document.querySelector("#screen-root .fixed-container.top .f2")?.innerText == 'Feeds';
-    if (fillerElm && !document.getElementById('feedsBtn') && !alreadyOnFeedsScreen) {
+    const innerScreenText = document.querySelector("#screen-root .fixed-container.top .f2")?.innerText || '';
+    const onInnerScreen = ['Feeds', 'Replies'].includes(innerScreenText);
+    if (fillerElm && !document.getElementById('feedsBtn') && !onInnerScreen) {
         const arbitraryOffset = 138;
         const leftPos = window.screen.width - arbitraryOffset;
         fillerElm.insertAdjacentHTML('afterend', `

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -125,7 +125,10 @@ const tryAddFeedsButton = () => {
     const fillerElm = document.querySelector('.filler');
     // TODO: Ensure localized
     const innerScreenText = document.querySelector("#screen-root .fixed-container.top .f2")?.innerText || '';
-    const onInnerScreen = ['Feeds', 'Replies', 'Review posts and tags'].includes(innerScreenText);
+    // This is really flakey, and it keeps failing
+    // TODO: Rewrite as an inclusion instead of excluding everything in the world
+    // FB is still largely an SPA and pushes to history infrequently
+    const onInnerScreen = ['Feeds', 'Replies', 'Review posts and tags', 'People who reacted', 'Messages'].includes(innerScreenText);
     if (fillerElm && !document.getElementById('feedsBtn') && !onInnerScreen) {
         const arbitraryOffset = 138;
         const leftPos = window.screen.width - arbitraryOffset;

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -123,7 +123,9 @@ autoReloadAfterIdle()
 // New Stuff
 const tryAddFeedsButton = () => {
     const fillerElm = document.querySelector('.filler');
-    if (fillerElm && !document.getElementById('feedsBtn')) {
+    // TODO: Ensure localized
+    const alreadyOnFeedsScreen = document.querySelector("#screen-root .fixed-container.top .f2")?.innerText == 'Feeds';
+    if (fillerElm && !document.getElementById('feedsBtn') && !alreadyOnFeedsScreen) {
         const arbitraryOffset = 138;
         const leftPos = window.screen.width - arbitraryOffset;
         fillerElm.insertAdjacentHTML('afterend', `

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -140,15 +140,7 @@ autoReloadAfterIdle();
 
 // Run initially if on "/"
 if (location.pathname === '/') {
-  root.style.overflow = 'visible';
-  const titleBarEle = root.querySelector('.filler').nextElementSibling;
-
-  const tabBarEle = titleBarEle.nextElementSibling;
-  tabBarEle.style.position = 'sticky';
-  tabBarEle.style.zIndex = 1;
-  tabBarEle.style.top = '0';
-
-  tryAddButtons(titleBarEle);
+  tryAddButtons();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -208,7 +200,7 @@ const groupLabels = {
   reels,
 };
 
-const allIgnoredGroups = [
+const blockedGroups = [
   ...new Set(allGroups.flatMap(group => (userPrefObj[group] === 'blocked' ? groupLabels[group] : [])).filter(d => d)),
 ];
 
@@ -306,7 +298,7 @@ function runObserver(callback) {
         for (const span of element.querySelectorAll(
           "span.f2:not(.a), span.f5, [style^='margin-top:9px; height:21px'] > .native-text"
         )) {
-          if (![...allIgnoredGroups].some(str => span.textContent.includes(str))) continue;
+          if (![...blockedGroups].some(str => span.textContent.includes(str))) continue;
           suspect = true;
           reason = span.innerHTML.split('󰞋')[0];
           raw = span.innerHTML;
@@ -459,7 +451,15 @@ const generateSettingsOverlay = () => `
     </div>
   </div>`;
 
-function tryAddButtons(titleBarEle) {
+function tryAddButtons() {
+  root.style.overflow = 'visible';
+  const titleBarEle = root.querySelector('.filler').nextElementSibling;
+
+  const tabBarEle = document.querySelector('[role="tablist"]');
+  tabBarEle.style.position = 'sticky';
+  tabBarEle.style.zIndex = 1;
+  tabBarEle.style.top = '0';
+
   const innerScreenText = document.querySelector('#screen-root .fixed-container.top .f2')?.innerText || '';
   const onInnerScreen = innerScreenText !== '';
   if (titleBarEle && !onInnerScreen) {

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -150,6 +150,7 @@ const sponsored = getLabels({
     'en': 'Sponsored',
     'bn': 'স্পনসর্ড'
 })
+
 // Uncategorized
 const unCategorized = getLabels({
     'en-US': ['Join', 'Follow'],
@@ -157,7 +158,25 @@ const unCategorized = getLabels({
     'bn': ['ফলো করুন', 'যোগ দিন']
 })
 
+// People you may know
+const peopleYouMayKnow = getLabels({
+    'en-US': 'People You May Know',
+    'en': 'People You May Know',
+})
 
+// Reels
+const reels = getLabels({
+    'en-US': 'Reels',
+    'en': 'Reels',
+})
+
+const allIgnoredGroups = [
+  ...suggested,
+  ...sponsored,
+  ...unCategorized,
+  ...peopleYouMayKnow,
+  ...reels,
+];
 
 //Whatever we wanna do with the convicts
 findConvicts((convicts) => {
@@ -252,8 +271,8 @@ function findConvicts(callback) {
                 let raw
                 let author
 
-                for (const span of element.querySelectorAll("span.f2:not(.a), span.f5")) {
-                    if (![...suggested, ...sponsored, ...unCategorized].some(str => span.textContent.includes(str))) continue
+                for (const span of element.querySelectorAll("span.f2:not(.a), span.f5, [style^='margin-top:9px; height:21px'] > .native-text")) {
+                    if (![...allIgnoredGroups].some(str => span.textContent.includes(str))) continue
                     suspect = true
                     reason = span.innerHTML.split("󰞋")[0]
                     raw = span.innerHTML

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -125,7 +125,7 @@ const tryAddFeedsButton = () => {
     const fillerElm = document.querySelector('.filler');
     // TODO: Ensure localized
     const innerScreenText = document.querySelector("#screen-root .fixed-container.top .f2")?.innerText || '';
-    const onInnerScreen = ['Feeds', 'Replies'].includes(innerScreenText);
+    const onInnerScreen = ['Feeds', 'Replies', 'Review posts and tags'].includes(innerScreenText);
     if (fillerElm && !document.getElementById('feedsBtn') && !onInnerScreen) {
         const arbitraryOffset = 138;
         const leftPos = window.screen.width - arbitraryOffset;

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -138,175 +138,17 @@ const spinner = new Spinner();
 // This is to simulatate to ensure latest data when user comes back to his phone after a while
 autoReloadAfterIdle();
 
-function generateTile({ heading, subHeading = '', iconChar = '', checkbox = true }) {
-  const generatedId = heading
-    .toLowerCase()
-    .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => (index === 0 ? word.toLowerCase() : word.toUpperCase()))
-    .replace(/\s+/g, '');
-
-  return `
-    <div id="${generatedId}Tile" class="m" style="margin-top:-1px; height:53px; z-index:0;">
-      <div class="m" style="margin-top:11px; height:32px; z-index:0; width:32px; margin-left:4px;">
-        <div class="fl ac">
-          <div class="native-text" style="width:32px; color:#e4e6eb;"><span class="f3">${iconChar}</span>
-          </div>
-        </div>
-      </div>
-      <div class="m" style="margin-top:-35px; height:21px; z-index:0; margin-left:40px; pointer-events: none;">
-        <div class="native-text" style="color:#e4e6eb;">${heading}</div>
-      </div>
-      <div class="m" style="height:16px; z-index:0; margin-left:40px; pointer-events: none;">
-        <div style="color:#b0b3b8;"><span class="f5">${subHeading}</span></div>
-      </div>
-      ${
-        checkbox
-          ? `<div class="m" style="margin-top:-22px; height:20px; z-index:0; width:20px; margin-left: 90%; pointer-events: none;">
-                <input type="checkbox" style="height: 100%; width: 100%;" id="${generatedId}Checkbox" ${
-              userPrefObj[generatedId] === 'blocked' ? 'checked="true"' : ''
-            } />
-            </div>`
-          : ''
-      }
-    </div>`;
-}
-
-const settingsOverlay = `
-<div id="settingsOverlay" class="dialog-screen"
-  style="min-height:100vh; width:${window.screen.width}px; background-color:rgba(0,0,0,0.49803922);">
-  <div class="m fixed-container bottom"
-    style="height:${(Object.keys(allGroups).length + 1) * 60}px; z-index:1; margin-top:0; width:${
-  window.screen.width
-}px;">
-    <div class="m">
-        <div class="m bg-s2">
-          <div class="m nb"
-            style="margin-top:12px; z-index:0; clip-path:inset(0 0 0 0 round 8px); --nbrad:8px; --nbr:0px; margin-left:8px; --nbc:#242526; --nbt:8px; --nbb:0px; width:${
-              window.screen.width - 18
-            }px; --nbl:0px;">
-            <div class="m bg-s3"
-              style="margin-top:3px; z-index:0; margin-left:-1px;">
-              ${[
-                {
-                  heading: 'Suggested',
-                  subHeading: 'Removes un-needed algorithm suggested posts',
-                  iconChar: bookmarkIcon,
-                },
-                {
-                  heading: 'Sponsored',
-                  subHeading: 'Removes annoying ads',
-                  iconChar: minusIcon,
-                },
-                {
-                  heading: 'Reels',
-                  subHeading: 'Removes annoying short videos',
-                  iconChar: reelsIcon,
-                },
-                {
-                  heading: 'People You May Know',
-                  subHeading: 'Removes suggested friends',
-                  iconChar: peopleIcon,
-                },
-                {
-                  heading: 'Uncategorized',
-                  subHeading: 'Removes suggested pages with join/follow link',
-                  iconChar: plusIcon,
-                },
-              ]
-                .map(generateTile)
-                .join('')}
-            </div>
-          </div>
-          <div class="m nb"
-            style="margin-top:12px; height:322px; z-index:0; clip-path:inset(0 0 0 0 round 8px); --nbrad:8px; --nbr:0px; margin-left:8px; --nbc:#242526; --nbt:8px; --nbb:0px; width:${
-              window.screen.width - 18
-            }px; --nbl:0px;">
-            <div class="m bg-s3"
-              style="margin-top:3px; z-index:0; margin-left:-1px;">
-              ${[
-                {
-                  heading: 'Close Menu',
-                  iconChar: closeIcon,
-                  checkbox: false,
-                },
-              ]
-                .map(generateTile)
-                .join('')}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>`;
-
-function tryAddButtons() {
-  const fillerElm = document.querySelector('.filler');
-  const innerScreenText = document.querySelector('#screen-root .fixed-container.top .f2')?.innerText || '';
-  const onInnerScreen = innerScreenText !== '';
-  if (fillerElm && !onInnerScreen) {
-    if (!document.getElementById('settingsBtn')) {
-      fillerElm.insertAdjacentHTML(
-        'afterend',
-        `
-          <div id="settingsBtn" style="z-index: 1;position: absolute;left: ${
-            window.screen.width - 138
-          }px; pointer-events: all;">
-              <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
-                  <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yC/r/FgGUIEUfnev.png" class="img contain" style="filter: grayscale(1);">
-              </div>
-          </div>`
-      );
-
-      document.getElementById('settingsBtn').addEventListener('click', e => {
-        document.body.innerHTML += settingsOverlay;
-
-        allGroups.forEach(groupName => {
-          document.getElementById(`${groupName}Tile`).addEventListener('click', ({ target }) => {
-            if (groupName === 'closeMenu') return;
-            const curPrefs = JSON.parse(localStorage.getItem('FBCleanMyFeeds') || '{}');
-            curPrefs[groupName] = curPrefs[groupName] === 'blocked' ? 'allowed' : 'blocked';
-            localStorage.setItem('FBCleanMyFeeds', JSON.stringify(curPrefs));
-
-            const parent = target.parentElement.parentElement;
-            const checkboxEle = parent.querySelector(`#${groupName}Checkbox`);
-            if (checkboxEle.getAttribute('checked') === 'true') {
-              checkboxEle.removeAttribute('checked');
-              return;
-            }
-            checkboxEle.setAttribute('checked', 'true');
-          });
-        });
-
-        document.getElementById('closeMenuTile').addEventListener('click', () => {
-          document.querySelector('#settingsOverlay')?.remove();
-          window.location.reload();
-        });
-      });
-    }
-
-    if (!document.getElementById('feedsBtn')) {
-      fillerElm.insertAdjacentHTML(
-        'afterend',
-        `
-          <div id="feedsBtn" style="z-index: 1;position: absolute;left: ${
-            window.screen.width - 180
-          }px; pointer-events: all;">
-              <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
-                  <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yB/r/Bc4BAjXDBat.png" class="img contain" style="filter: grayscale(1);">
-              </div>
-          </div>`
-      );
-
-      document.getElementById('feedsBtn').addEventListener('click', () => {
-        document.querySelector('[aria-label="Facebook Menu"]').click();
-        window.setTimeout(() => document.querySelector('[aria-label="Feeds"]').click(), 500);
-      });
-    }
-  }
-}
-
 // Run initially if on "/"
 if (location.pathname === '/') {
-  tryAddButtons();
+  root.style.overflow = 'visible';
+  const titleBarEle = root.querySelector('.filler').nextElementSibling;
+
+  const tabBarEle = titleBarEle.nextElementSibling;
+  tabBarEle.style.position = 'sticky';
+  tabBarEle.style.zIndex = 1;
+  tabBarEle.style.top = '0';
+
+  tryAddButtons(titleBarEle);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -366,9 +208,11 @@ const groupLabels = {
   reels,
 };
 
-const allIgnoredGroups = allGroups.map(group => (userPrefObj[group] === 'blocked' ? groupLabels[group] : [])).flat();
+const allIgnoredGroups = [
+  ...new Set(allGroups.flatMap(group => (userPrefObj[group] === 'blocked' ? groupLabels[group] : [])).filter(d => d)),
+];
 
-//Whatever we wanna do with the convicts
+// Whatever we wanna do with the convicts
 runObserver(convicts => {
   console.table(convicts);
   for (const { element, reason, author } of convicts) {
@@ -513,4 +357,169 @@ function autoReloadAfterIdle(minutes = 15) {
       if (timeDiff > minutes) location.reload();
     }
   });
+}
+
+function generateSettingsTile({ heading, subHeading = '', iconChar = '', checkbox = true }) {
+  const generatedId = heading
+    .toLowerCase()
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => (index === 0 ? word.toLowerCase() : word.toUpperCase()))
+    .replace(/\s+/g, '');
+
+  return `
+    <div id="${generatedId}Tile" class="m" style="margin-top:-1px; height:53px; z-index:0;">
+      <div class="m" style="margin-top:11px; height:32px; z-index:0; width:32px; margin-left:4px;">
+        <div class="fl ac">
+          <div class="native-text" style="width:32px; color:#e4e6eb;"><span class="f3">${iconChar}</span>
+          </div>
+        </div>
+      </div>
+      <div class="m" style="margin-top:-35px; height:21px; z-index:0; margin-left:40px; pointer-events: none;">
+        <div class="native-text" style="color:#e4e6eb;">${heading}</div>
+      </div>
+      <div class="m" style="height:16px; z-index:0; margin-left:40px; pointer-events: none;">
+        <div style="color:#b0b3b8;"><span class="f5">${subHeading}</span></div>
+      </div>
+      ${
+        checkbox
+          ? `<div class="m" style="margin-top:-22px; height:20px; z-index:0; width:20px; margin-left: 90%; pointer-events: none;">
+                <input type="checkbox" style="height: 100%; width: 100%;" id="${generatedId}Checkbox" ${
+              userPrefObj[generatedId] === 'blocked' ? 'checked="true"' : ''
+            } />
+            </div>`
+          : ''
+      }
+    </div>`;
+}
+
+const generateSettingsOverlay = () => `
+<div id="settingsOverlay" class="dialog-screen"
+  style="min-height:100vh; width:${window.screen.width}px; background-color:rgba(0,0,0,0.49803922);">
+  <div class="m fixed-container bottom"
+    style="height:${(Object.keys(allGroups).length + 1) * 60}px; z-index:1; margin-top:0; width:${
+  window.screen.width
+}px;">
+    <div class="m">
+        <div class="m bg-s2">
+          <div class="m nb"
+            style="margin-top:12px; z-index:0; clip-path:inset(0 0 0 0 round 8px); --nbrad:8px; --nbr:0px; margin-left:8px; --nbc:#242526; --nbt:8px; --nbb:0px; width:${
+              window.screen.width - 18
+            }px; --nbl:0px;">
+            <div class="m bg-s3"
+              style="margin-top:3px; z-index:0; margin-left:-1px;">
+              ${[
+                {
+                  heading: 'Suggested',
+                  subHeading: 'Removes un-needed algorithm suggested posts',
+                  iconChar: bookmarkIcon,
+                },
+                {
+                  heading: 'Sponsored',
+                  subHeading: 'Removes annoying ads',
+                  iconChar: minusIcon,
+                },
+                {
+                  heading: 'Reels',
+                  subHeading: 'Removes annoying short videos',
+                  iconChar: reelsIcon,
+                },
+                {
+                  heading: 'People You May Know',
+                  subHeading: 'Removes suggested friends',
+                  iconChar: peopleIcon,
+                },
+                {
+                  heading: 'Uncategorized',
+                  subHeading: 'Removes suggested pages with join/follow link',
+                  iconChar: plusIcon,
+                },
+              ]
+                .map(generateSettingsTile)
+                .join('')}
+            </div>
+          </div>
+          <div class="m nb"
+            style="margin-top:12px; height:322px; z-index:0; clip-path:inset(0 0 0 0 round 8px); --nbrad:8px; --nbr:0px; margin-left:8px; --nbc:#242526; --nbt:8px; --nbb:0px; width:${
+              window.screen.width - 18
+            }px; --nbl:0px;">
+            <div class="m bg-s3"
+              style="margin-top:3px; z-index:0; margin-left:-1px;">
+              ${[
+                {
+                  heading: 'Close Menu',
+                  iconChar: closeIcon,
+                  checkbox: false,
+                },
+              ]
+                .map(generateSettingsTile)
+                .join('')}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>`;
+
+function tryAddButtons(titleBarEle) {
+  const innerScreenText = document.querySelector('#screen-root .fixed-container.top .f2')?.innerText || '';
+  const onInnerScreen = innerScreenText !== '';
+  if (titleBarEle && !onInnerScreen) {
+    if (!document.getElementById('settingsBtn')) {
+      titleBarEle.insertAdjacentHTML(
+        'afterend',
+        `
+          <div id="settingsBtn" style="z-index: 2; position: absolute; left: ${
+            window.screen.width - 138
+          }px; pointer-events: all;">
+              <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
+                  <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yC/r/FgGUIEUfnev.png" class="img contain" style="filter: grayscale(1);">
+              </div>
+          </div>`
+      );
+
+      document.getElementById('settingsBtn').addEventListener('click', e => {
+        document.body.innerHTML += generateSettingsOverlay();
+
+        allGroups.forEach(groupName => {
+          document.getElementById(`${groupName}Tile`).addEventListener('click', ({ target }) => {
+            if (groupName === 'closeMenu') return;
+            const curPrefs = JSON.parse(localStorage.getItem('FBCleanMyFeeds') || '{}');
+            curPrefs[groupName] = curPrefs[groupName] === 'blocked' ? 'allowed' : 'blocked';
+            localStorage.setItem('FBCleanMyFeeds', JSON.stringify(curPrefs));
+
+            const parent = target.parentElement.parentElement;
+            const checkboxEle = parent.querySelector(`#${groupName}Checkbox`);
+            if (checkboxEle.getAttribute('checked') === 'true') {
+              checkboxEle.removeAttribute('checked');
+              return;
+            }
+            checkboxEle.setAttribute('checked', 'true');
+          });
+        });
+
+        document.getElementById('closeMenuTile').addEventListener('click', () => {
+          document.querySelector('#settingsOverlay')?.remove();
+          window.location.reload();
+        });
+      });
+    }
+
+    if (!document.getElementById('feedsBtn')) {
+      titleBarEle.insertAdjacentHTML(
+        'afterend',
+        `
+          <div id="feedsBtn" style="z-index: 2; position: absolute; left: ${
+            window.screen.width - 180
+          }px; pointer-events: all;">
+              <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
+                  <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yB/r/Bc4BAjXDBat.png" class="img contain" style="filter: grayscale(1);">
+              </div>
+          </div>`
+      );
+
+      document.getElementById('feedsBtn').addEventListener('click', () => {
+        document.querySelector('[aria-label="Facebook Menu"]').click();
+        window.setTimeout(() => document.querySelector('[aria-label="Feeds"]').click(), 500);
+      });
+    }
+  }
 }

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -121,25 +121,30 @@ autoReloadAfterIdle()
 // `)
 
 // New Stuff
-// Button to Feeds
-const fillerElm = document.querySelector('.filler');
-if (fillerElm) {
-  const arbitraryOffset = 138;
-  const leftPos = window.screen.width - arbitraryOffset;
-  fillerElm.insertAdjacentHTML('afterend',`
-    <div id="feedsBtn"
-         style="z-index: 1;position: absolute;left: ${leftPos}px; pointer-events: all;">
-      <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
-        <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yB/r/Bc4BAjXDBat.png" class="img contain" style="filter: grayscale(1);">
-      </div>
-    </div>`);
+const tryAddFeedsButton = () => {
+    const fillerElm = document.querySelector('.filler');
+    if (fillerElm && !document.getElementById('feedsBtn')) {
+        const arbitraryOffset = 138;
+        const leftPos = window.screen.width - arbitraryOffset;
+        fillerElm.insertAdjacentHTML('afterend', `
+            <div id="feedsBtn" style="z-index: 1;position: absolute;left: ${leftPos}px;pointer-events: all;">
+                <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
+                    <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yB/r/Bc4BAjXDBat.png" class="img contain" style="filter: grayscale(1);">
+                </div>
+            </div>`);
 
-  document.getElementById('feedsBtn').addEventListener('click', function() {
-    document.querySelector('[aria-label="Facebook Menu"]').click();
-    window.setTimeout(function() {
-      document.querySelector('[aria-label="Feeds"]').click();
-    }, 500);
-  });
+        document.getElementById('feedsBtn').addEventListener('click', function () {
+            document.querySelector('[aria-label="Facebook Menu"]').click();
+            window.setTimeout(function () {
+                document.querySelector('[aria-label="Feeds"]').click();
+            }, 500);
+        });
+    }
+};
+
+// Run initially if on "/"
+if (location.pathname === "/") {
+    tryAddFeedsButton();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -201,7 +206,7 @@ const allIgnoredGroups = [
 ];
 
 //Whatever we wanna do with the convicts
-findConvicts((convicts) => {
+runObserver((convicts) => {
 
     console.table(convicts)
     for (const { element, reason, author } of convicts) {
@@ -273,9 +278,12 @@ findConvicts((convicts) => {
 ////////////////////         function definitions       ////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-function findConvicts(callback) {
+function runObserver(callback) {
     const observer = new MutationObserver((mutationList, observer) => {
         if (location.pathname !== '/') return
+
+        tryAddFeedsButton();
+        
         if (devMode) console.time()
         spinner.show()
         const convicts = []

--- a/FB Mobile - Clean my feeds.user.js
+++ b/FB Mobile - Clean my feeds.user.js
@@ -26,21 +26,44 @@
 // As filler height goes from say 5000px to 500px in a second when we update it ourselves.
 // After scrolling for a while, they just keep spamming suggested posts and ads. So you will often see the "Loading more posts" element.
 
-const devMode = false
-const showPlaceholder = true
+const devMode = false;
+const showPlaceholder = true;
 
+// Icons
+const plusIcon = '󱠂';
+const minusIcon = '󱠑';
+const shareIcon = '󱙳';
+const closeIcon = '󱙳';
+const bookmarkIcon = '󱤁';
+const reelsIcon = '󰎃';
+const peopleIcon = '󰎍';
+
+const allGroups = ['suggested', 'sponsored', 'uncategorized', 'peopleYouMayKnow', 'reels'];
+
+// TODO: Change to camelcase for consistency
+const userPrefString =
+  localStorage.getItem('FBCleanMyFeeds') ||
+  JSON.stringify({
+    suggested: 'blocked',
+    sponsored: 'blocked',
+    uncategorized: 'blocked',
+    peopleYouMayKnow: 'blocked',
+    reels: 'blocked',
+  });
+
+let userPrefObj = JSON.parse(userPrefString);
 
 // Make sure this is the React-Mobile version of facebook
-if (document.body.id !== "app-body") {
-    console.error("ID 'app-body' not found.")
-    return
+if (document.body.id !== 'app-body') {
+  console.error("ID 'app-body' not found.");
+  return;
 }
 
 // React root
-const root = document.querySelector('#screen-root')
+const root = document.querySelector('#screen-root');
 if (!root) {
-    console.error("screen-root not found")
-    return
+  console.error('screen-root not found');
+  return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,51 +71,57 @@ if (!root) {
 ////////////////////////////////////////////////////////////////////////////////
 
 class Spinner {
-    constructor() {
-        this.elm = document.createElement("div")
-        this.elm.id = "block-counter"
-        Object.assign(this.elm.style, { position: "fixed", top: "20px", left: "16px", pointerEvents: "none", zIndex: 100 })
-        this.elm.innerHTML = `<div class="spinner small animated"></div>`
-        document.body.appendChild(this.elm)
-    }
-
-    show() {
-        this.elm.style.display = "block"
-    }
-
-    hide() {
-        this.elm.style.display = "none"
-    }
+  constructor() {
+    this.elm = document.createElement('div');
+    this.elm.id = 'block-counter';
+    Object.assign(this.elm.style, { position: 'fixed', top: '20px', left: '16px', pointerEvents: 'none', zIndex: 100 });
+    this.elm.innerHTML = `<div class="spinner small animated"></div>`;
+    document.body.appendChild(this.elm);
+  }
+  show() {
+    this.elm.style.display = 'block';
+  }
+  hide() {
+    this.elm.style.display = 'none';
+  }
 }
 
 class BlockCounter {
-    whitelisted = 0
-    blacklisted = 0
+  whitelisted = 0;
+  blacklisted = 0;
 
-    constructor() {
-        if (!devMode) return
-        this.elm = document.createElement("div")
-        document.body.appendChild(this.elm)
-        Object.assign(this.elm.style, { position: "fixed", top: 0, right: 0, padding: ".5rem 1rem", background: "#323436", borderRadius: ".2rem", display: "flex", flexFlow: "row wrap", zIndex: 99, color: "#ddd", gap: ".5rem", fontSize: ".8rem", pointerEvents: "none", })
-        this.render()
-    }
-
-    render() {
-        if (devMode) this.elm.innerHTML = `
-            <p>Whitelisted: ${this.whitelisted}</p>
-            <p>Blacklisted: ${this.blacklisted}</p>
-        `
-    }
-
-    increaseWhite() {
-        this.whitelisted += 1
-        this.render()
-    }
-
-    increaseBlack() {
-        this.blacklisted += 1
-        this.render()
-    }
+  constructor() {
+    if (!devMode) return;
+    this.elm = document.createElement('div');
+    document.body.appendChild(this.elm);
+    Object.assign(this.elm.style, {
+      position: 'fixed',
+      top: 0,
+      right: 0,
+      padding: '.5rem 1rem',
+      background: '#323436',
+      borderRadius: '.2rem',
+      display: 'flex',
+      flexFlow: 'row wrap',
+      zIndex: 99,
+      color: '#ddd',
+      gap: '.5rem',
+      fontSize: '.8rem',
+      pointerEvents: 'none',
+    });
+    this.render();
+  }
+  render() {
+    if (devMode) this.elm.innerHTML = `<p>Whitelisted: ${this.whitelisted}</p><p>Blacklisted: ${this.blacklisted}</p>`;
+  }
+  increaseWhite() {
+    this.whitelisted += 1;
+    this.render();
+  }
+  increaseBlack() {
+    this.blacklisted += 1;
+    this.render();
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,57 +129,184 @@ class BlockCounter {
 ////////////////////////////////////////////////////////////////////////////////
 
 // Show counter on top
-const counter = new BlockCounter()
+const counter = new BlockCounter();
 
 // Show spinner while operating
-const spinner = new Spinner()
+const spinner = new Spinner();
 
 // Auto reloads app when idle for 15 minutes
 // This is to simulatate to ensure latest data when user comes back to his phone after a while
-autoReloadAfterIdle()
+autoReloadAfterIdle();
 
+function generateTile({ heading, subHeading = '', iconChar = '', checkbox = true }) {
+  const generatedId = heading
+    .toLowerCase()
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => (index === 0 ? word.toLowerCase() : word.toUpperCase()))
+    .replace(/\s+/g, '');
 
-// Some other styles
-// GM_addStyle(`
+  return `
+    <div id="${generatedId}Tile" class="m" style="margin-top:-1px; height:53px; z-index:0;">
+      <div class="m" style="margin-top:11px; height:32px; z-index:0; width:32px; margin-left:4px;">
+        <div class="fl ac">
+          <div class="native-text" style="width:32px; color:#e4e6eb;"><span class="f3">${iconChar}</span>
+          </div>
+        </div>
+      </div>
+      <div class="m" style="margin-top:-35px; height:21px; z-index:0; margin-left:40px; pointer-events: none;">
+        <div class="native-text" style="color:#e4e6eb;">${heading}</div>
+      </div>
+      <div class="m" style="height:16px; z-index:0; margin-left:40px; pointer-events: none;">
+        <div style="color:#b0b3b8;"><span class="f5">${subHeading}</span></div>
+      </div>
+      ${
+        checkbox
+          ? `<div class="m" style="margin-top:-22px; height:20px; z-index:0; width:20px; margin-left: 90%; pointer-events: none;">
+                <input type="checkbox" style="height: 100%; width: 100%;" id="${generatedId}Checkbox" ${
+              userPrefObj[generatedId] === 'blocked' ? 'checked="true"' : ''
+            } />
+            </div>`
+          : ''
+      }
+    </div>`;
+}
 
-//     /* remove install app toast */
-//     div[data-comp-id~="22222"]:has([data-action-id~="32764"]){
-//       display: none !important;
-//     }
+const settingsOverlay = `
+<div id="settingsOverlay" class="dialog-screen"
+  style="min-height:100vh; width:${window.screen.width}px; background-color:rgba(0,0,0,0.49803922);">
+  <div class="m fixed-container bottom"
+    style="height:${(Object.keys(allGroups).length + 1) * 60}px; z-index:1; margin-top:0; width:${
+  window.screen.width
+}px;">
+    <div class="m">
+        <div class="m bg-s2">
+          <div class="m nb"
+            style="margin-top:12px; z-index:0; clip-path:inset(0 0 0 0 round 8px); --nbrad:8px; --nbr:0px; margin-left:8px; --nbc:#242526; --nbt:8px; --nbb:0px; width:${
+              window.screen.width - 18
+            }px; --nbl:0px;">
+            <div class="m bg-s3"
+              style="margin-top:3px; z-index:0; margin-left:-1px;">
+              ${[
+                {
+                  heading: 'Suggested',
+                  subHeading: 'Removes un-needed algorithm suggested posts',
+                  iconChar: bookmarkIcon,
+                },
+                {
+                  heading: 'Sponsored',
+                  subHeading: 'Removes annoying ads',
+                  iconChar: minusIcon,
+                },
+                {
+                  heading: 'Reels',
+                  subHeading: 'Removes annoying short videos',
+                  iconChar: reelsIcon,
+                },
+                {
+                  heading: 'People You May Know',
+                  subHeading: 'Removes suggested friends',
+                  iconChar: peopleIcon,
+                },
+                {
+                  heading: 'Uncategorized',
+                  subHeading: 'Removes suggested pages with join/follow link',
+                  iconChar: plusIcon,
+                },
+              ]
+                .map(generateTile)
+                .join('')}
+            </div>
+          </div>
+          <div class="m nb"
+            style="margin-top:12px; height:322px; z-index:0; clip-path:inset(0 0 0 0 round 8px); --nbrad:8px; --nbr:0px; margin-left:8px; --nbc:#242526; --nbt:8px; --nbb:0px; width:${
+              window.screen.width - 18
+            }px; --nbl:0px;">
+            <div class="m bg-s3"
+              style="margin-top:3px; z-index:0; margin-left:-1px;">
+              ${[
+                {
+                  heading: 'Close Menu',
+                  iconChar: closeIcon,
+                  checkbox: false,
+                },
+              ]
+                .map(generateTile)
+                .join('')}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>`;
 
-// `)
+function tryAddButtons() {
+  const fillerElm = document.querySelector('.filler');
+  const innerScreenText = document.querySelector('#screen-root .fixed-container.top .f2')?.innerText || '';
+  const onInnerScreen = innerScreenText !== '';
+  if (fillerElm && !onInnerScreen) {
+    if (!document.getElementById('settingsBtn')) {
+      fillerElm.insertAdjacentHTML(
+        'afterend',
+        `
+          <div id="settingsBtn" style="z-index: 1;position: absolute;left: ${
+            window.screen.width - 138
+          }px; pointer-events: all;">
+              <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
+                  <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yC/r/FgGUIEUfnev.png" class="img contain" style="filter: grayscale(1);">
+              </div>
+          </div>`
+      );
 
-// New Stuff
-const tryAddFeedsButton = () => {
-    const fillerElm = document.querySelector('.filler');
-    // TODO: Ensure localized
-    const innerScreenText = document.querySelector("#screen-root .fixed-container.top .f2")?.innerText || '';
-    // This is really flakey, and it keeps failing
-    // TODO: Rewrite as an inclusion instead of excluding everything in the world
-    // FB is still largely an SPA and pushes to history infrequently
-    const onInnerScreen = ['Feeds', 'Replies', 'Review posts and tags', 'People who reacted', 'Edit Post', 'Privacy'].includes(innerScreenText);
-    if (fillerElm && !document.getElementById('feedsBtn') && !onInnerScreen) {
-        const arbitraryOffset = 138;
-        const leftPos = window.screen.width - arbitraryOffset;
-        fillerElm.insertAdjacentHTML('afterend', `
-            <div id="feedsBtn" style="z-index: 1;position: absolute;left: ${leftPos}px;pointer-events: all;">
-                <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
-                    <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yB/r/Bc4BAjXDBat.png" class="img contain" style="filter: grayscale(1);">
-                </div>
-            </div>`);
+      document.getElementById('settingsBtn').addEventListener('click', e => {
+        document.body.innerHTML += settingsOverlay;
 
-        document.getElementById('feedsBtn').addEventListener('click', function () {
-            document.querySelector('[aria-label="Facebook Menu"]').click();
-            window.setTimeout(function () {
-                document.querySelector('[aria-label="Feeds"]').click();
-            }, 500);
+        allGroups.forEach(groupName => {
+          document.getElementById(`${groupName}Tile`).addEventListener('click', ({ target }) => {
+            if (groupName === 'closeMenu') return;
+            const curPrefs = JSON.parse(localStorage.getItem('FBCleanMyFeeds') || '{}');
+            curPrefs[groupName] = curPrefs[groupName] === 'blocked' ? 'allowed' : 'blocked';
+            localStorage.setItem('FBCleanMyFeeds', JSON.stringify(curPrefs));
+
+            const parent = target.parentElement.parentElement;
+            const checkboxEle = parent.querySelector(`#${groupName}Checkbox`);
+            if (checkboxEle.getAttribute('checked') === 'true') {
+              checkboxEle.removeAttribute('checked');
+              return;
+            }
+            checkboxEle.setAttribute('checked', 'true');
+          });
         });
+
+        document.getElementById('closeMenuTile').addEventListener('click', () => {
+          document.querySelector('#settingsOverlay')?.remove();
+          window.location.reload();
+        });
+      });
     }
-};
+
+    if (!document.getElementById('feedsBtn')) {
+      fillerElm.insertAdjacentHTML(
+        'afterend',
+        `
+          <div id="feedsBtn" style="z-index: 1;position: absolute;left: ${
+            window.screen.width - 180
+          }px; pointer-events: all;">
+              <div class="m bg-s4" style="margin-top:4px; height:35px; z-index:0; width:35px; margin-left:5px; --diameter:35px;">
+                  <img src="https://static.xx.fbcdn.net/rsrc.php/v4/yB/r/Bc4BAjXDBat.png" class="img contain" style="filter: grayscale(1);">
+              </div>
+          </div>`
+      );
+
+      document.getElementById('feedsBtn').addEventListener('click', () => {
+        document.querySelector('[aria-label="Facebook Menu"]').click();
+        window.setTimeout(() => document.querySelector('[aria-label="Feeds"]').click(), 500);
+      });
+    }
+  }
+}
 
 // Run initially if on "/"
-if (location.pathname === "/") {
-    tryAddFeedsButton();
+if (location.pathname === '/') {
+  tryAddButtons();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -159,228 +315,202 @@ if (location.pathname === "/") {
 
 // this version of fb does not update navigator.lang on language change
 // navigator.langs contain all of your preset languages. So we need to loop through it
-const getLabels = obj => navigator.languages.map(lang => obj[lang]).flat()
+const getLabels = obj => navigator.languages.map(lang => obj[lang]).flat();
 
-if (devMode) console.log("navigator.languages", navigator.languages)
+if (devMode) console.log('navigator.languages', navigator.languages);
 // Placeholder Message
 const placeholderMsg = getLabels({
-    'en-US': 'Removed',
-    'en': 'Removed',
-    'bn': 'বাতিল'
-})[0]
-// To be fixed later
+  'en-US': 'Removed',
+  en: 'Removed',
+  bn: 'বাতিল',
+})[0];
 
 // Suggested
 const suggested = getLabels({
-    'en-US': 'Suggested',
-    'en': 'Suggested',
-    'bn': 'আপনার জন্য প্রস্তাবিত'
-})
+  'en-US': 'Suggested',
+  en: 'Suggested',
+  bn: 'আপনার জন্য প্রস্তাবিত',
+});
 
 // Sponsored
 const sponsored = getLabels({
-    'en-US': 'Sponsored',
-    'en': 'Sponsored',
-    'bn': 'স্পনসর্ড'
-})
+  'en-US': 'Sponsored',
+  en: 'Sponsored',
+  bn: 'স্পনসর্ড',
+});
 
 // Uncategorized
-const unCategorized = getLabels({
-    'en-US': ['Join', 'Follow'],
-    'en': ['Join', 'Follow'],
-    'bn': ['ফলো করুন', 'যোগ দিন']
-})
+const uncategorized = getLabels({
+  'en-US': ['Join', 'Follow'],
+  en: ['Join', 'Follow'],
+  bn: ['ফলো করুন', 'যোগ দিন'],
+});
 
 // People you may know
 const peopleYouMayKnow = getLabels({
-    'en-US': 'People You May Know',
-    'en': 'People You May Know',
-})
+  'en-US': 'People You May Know',
+  en: 'People You May Know',
+});
 
 // Reels
 const reels = getLabels({
-    'en-US': 'Reels',
-    'en': 'Reels',
-})
+  'en-US': 'Reels',
+  en: 'Reels',
+});
 
-const allIgnoredGroups = [
-  ...suggested,
-  ...sponsored,
-  ...unCategorized,
-  ...peopleYouMayKnow,
-  ...reels,
-];
+const groupLabels = {
+  suggested,
+  sponsored,
+  uncategorized,
+  peopleYouMayKnow,
+  reels,
+};
+
+const allIgnoredGroups = allGroups.map(group => (userPrefObj[group] === 'blocked' ? groupLabels[group] : [])).flat();
 
 //Whatever we wanna do with the convicts
-runObserver((convicts) => {
+runObserver(convicts => {
+  console.table(convicts);
+  for (const { element, reason, author } of convicts) {
+    element.tabIndex = '-1';
+    element.dataset.purged = 'true';
 
-    console.table(convicts)
-    for (const { element, reason, author } of convicts) {
-        element.tabIndex = "-1"
-        element.dataset.purged = "true"
+    // Sponsored posts get removed in an "out of order" fashion automatically.
+    // Having placeholder inside them results in a  scroll jump
+    if (showPlaceholder && !sponsored.includes(reason)) {
+      element.dataset.actualHeight = '32';
+      Object.assign(element.style, {
+        height: '32px',
+        overflowY: 'hidden',
+        pointerEvents: 'none',
+        position: 'relative',
+      });
 
+      const overlay = document.createElement('div');
+      Object.assign(overlay.style, {
+        position: 'absolute',
+        inset: 0,
+        background: '#242526',
+        color: '#e4e6eb',
+        display: 'grid',
+        pointerEvents: 'auto',
+        placeItems: 'center',
+        paddingInline: '.5rem',
+      });
+      overlay.innerHTML = `<p style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap; width: 100%; text-align: center;">${placeholderMsg}: ${author} (${reason})</p>`;
+      element.appendChild(overlay);
+    } else {
+      // Hide elements by resizing to 0px
+      // Removing from DOM or display:none causes issues loading newer posts
+      element.dataset.actualHeight = '0';
+      Object.assign(element.style, {
+        height: '0px',
+        overflowY: 'hidden',
+        pointerEvents: 'none',
+      });
 
-        // Sponsored posts get removed in an "out of order" fashion automatically.
-        // Having placeholder inside them results in a  scroll jump
-        if (showPlaceholder && !(sponsored.includes(reason))) {
-            element.dataset.actualHeight = "32"
-            Object.assign(element.style, {
-                height: "32px",
-                overflowY: "hidden",
-                pointerEvents: "none",
-                position: "relative"
-            })
-
-            const overlay = document.createElement("div")
-            Object.assign(overlay.style, {
-                position: "absolute",
-                inset: 0,
-                background: "#242526",
-                color: "#e4e6eb",
-                display: "grid",
-                pointerEvents: "auto",
-                placeItems: "center",
-                paddingInline: ".5rem"
-            })
-            overlay.innerHTML = `
-                <p style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap; width: 100%; text-align: center;">
-                    ${placeholderMsg}: ${author} (${reason})
-                </p>
-            `
-            element.appendChild(overlay)
-
-        } else {
-            // Hide elements by resizing to 0px
-            // Removing from DOM or display:none causes issues loading newer posts
-            element.dataset.actualHeight = "0"
-            Object.assign(element.style, {
-                height: "0px",
-                overflowY: "hidden",
-                pointerEvents: "none"
-            })
-
-            //Hiding divider element preceding convicted element
-            const { previousElementSibling: prevElm } = element
-            if (prevElm.dataset.actualHeight !== "1") continue
-            prevElm.style.marginTop = "0px"
-            prevElm.style.height = "0px"
-            prevElm.dataset.actualHeight = "0"
-        }
-
-
-        // Removing image links to restrict downloading unnecessary content
-        for (const image of element.querySelectorAll("img")) {
-            image.dataset.src = image.src
-            //Clearing out src doesn't work as it gets populated again automatically
-            image.removeAttribute("src")
-            image.dataset.nulled = true
-        }
+      //Hiding divider element preceding convicted element
+      const { previousElementSibling: prevElm } = element;
+      if (prevElm.dataset.actualHeight !== '1') continue;
+      prevElm.style.marginTop = '0px';
+      prevElm.style.height = '0px';
+      prevElm.dataset.actualHeight = '0';
     }
 
-})
-
+    // Removing image links to restrict downloading unnecessary content
+    for (const image of element.querySelectorAll('img')) {
+      image.dataset.src = image.src;
+      //Clearing out src doesn't work as it gets populated again automatically
+      image.removeAttribute('src');
+      image.dataset.nulled = true;
+    }
+  }
+});
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////         function definitions       ////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
 function runObserver(callback) {
-    const observer = new MutationObserver((mutationList, observer) => {
-        if (location.pathname !== '/') return
+  const observer = new MutationObserver((mutationList, observer) => {
+    if (location.pathname !== '/') return;
 
-        tryAddFeedsButton();
-        
-        if (devMode) console.time()
-        spinner.show()
-        const convicts = []
+    tryAddButtons();
 
-        for (const mutation of mutationList) {
-            if (!(mutation.type === "childList" && mutation.target.matches("[data-type='vscroller']") && mutation.addedNodes.length !== 0)) continue
-            // console.log(mutation)
-            // console.table([...mutation.addedNodes].map(item => ({elm:item ,id: item.dataset.trackingDurationId, height: item.dataset.actualHeight})))
-            for (const element of mutation.addedNodes) {
-                // Check if element is an actual facebook post
-                if (!(element.hasAttribute("data-tracking-duration-id"))) continue
+    if (devMode) console.time();
+    spinner.show();
+    const convicts = [];
 
-                let suspect = false
-                let reason
-                let raw
-                let author
+    for (const mutation of mutationList) {
+      if (
+        !(
+          mutation.type === 'childList' &&
+          mutation.target.matches("[data-type='vscroller']") &&
+          mutation.addedNodes.length !== 0
+        )
+      )
+        continue;
+      // console.log(mutation)
+      // console.table([...mutation.addedNodes].map(item => ({elm:item ,id: item.dataset.trackingDurationId, height: item.dataset.actualHeight})))
+      for (const element of mutation.addedNodes) {
+        // Check if element is an actual facebook post
+        if (!element.hasAttribute('data-tracking-duration-id')) continue;
 
-                for (const span of element.querySelectorAll("span.f2:not(.a), span.f5, [style^='margin-top:9px; height:21px'] > .native-text")) {
-                    if (![...allIgnoredGroups].some(str => span.textContent.includes(str))) continue
-                    suspect = true
-                    reason = span.innerHTML.split("󰞋")[0]
-                    raw = span.innerHTML
-                    break
-                }
+        let suspect = false;
+        let reason, raw, author;
 
-                if (suspect) {
-                    author = element.querySelector("span.f2").innerHTML
-                    if (author.includes("Sponsored")) console.log("Author contains Sponsored", element)
-                }
-
-                if (suspect) {
-                    convicts.push({
-                        element,
-                        reason,
-                        raw,
-                        id: element.dataset.trackingDurationId,
-                        author
-                    })
-                    counter.increaseBlack()
-                } else {
-                    counter.increaseWhite()
-                }
-
-            }
+        for (const span of element.querySelectorAll(
+          "span.f2:not(.a), span.f5, [style^='margin-top:9px; height:21px'] > .native-text"
+        )) {
+          if (![...allIgnoredGroups].some(str => span.textContent.includes(str))) continue;
+          suspect = true;
+          reason = span.innerHTML.split('󰞋')[0];
+          raw = span.innerHTML;
+          break;
         }
 
-        if (!!convicts.length) callback(convicts)
+        if (suspect) {
+          author = element.querySelector('span.f2').innerHTML;
+          if (author.includes('Sponsored')) console.log('Author contains Sponsored', element);
+        }
 
-        if (devMode) console.timeEnd()
-        spinner.hide()
-        // Set new calculated height to the bottom ".filler" element
-        // We need to calculate it after all the convicts are taken care of
-        // *** It seems we dont need it anymore. Completely hiding "Sponsored" posts fixed it for us
-        // setFillerHeight(mutationList)
-    })
+        if (suspect) {
+          convicts.push({
+            element,
+            reason,
+            raw,
+            id: element.dataset.trackingDurationId,
+            author,
+          });
+          counter.increaseBlack();
+        } else {
+          counter.increaseWhite();
+        }
+      }
+    }
 
-    observer.observe(root, {
-        childList: true,
-        subtree: true,
-    })
+    if (!!convicts.length) callback(convicts);
+
+    if (devMode) console.timeEnd();
+    spinner.hide();
+  });
+
+  observer.observe(root, {
+    childList: true,
+    subtree: true,
+  });
 }
-
-// setFillerHeight is omitted
-// function setFillerHeight(mutationList) {
-//     const fillerNode = document.querySelectorAll('.filler')[1]
-//     if (!fillerNode) return
-//     let newHeight = 0
-//     for (const mutation of mutationList) {
-//         if (!(mutation.type === "childList" && mutation.target.matches("[data-type='vscroller']") && mutation.addedNodes.length !== 0)) continue
-
-//         newHeight += [...mutation.addedNodes].reduce((accumulator, element) => (
-//             accumulator += element.classList.contains('displayed') || element.classList.contains('filler') ? 0 : element.clientHeight
-//         ), 0)
-//     }
-//     fillerNode.style.height = newHeight
-// }
-
 
 function autoReloadAfterIdle(minutes = 15) {
-    let leaveTime
+  let leaveTime;
 
-    document.addEventListener('visibilitychange', () => {
-        if (document.hidden) {
-            leaveTime = new Date()
-        } else {
-            let currentTime = new Date()
-            let timeDiff = (currentTime - leaveTime) / 60000
-            if (timeDiff > minutes) location.reload()
-        }
-    })
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      leaveTime = new Date();
+    } else {
+      let currentTime = new Date();
+      let timeDiff = (currentTime - leaveTime) / 60000;
+      if (timeDiff > minutes) location.reload();
+    }
+  });
 }
-
-
-


### PR DESCRIPTION
### Intro
Hello, this is my first time working on a userscript. I found this script worked quite well and allowed me to cut down on distractions and annoyances on Facebook. I ran the code through a linter and added some additional features. I hope we can continue to add some more configurability and blocking options later. I apologize if the diff is a bit hard to read with the restructuring. I'm open to any suggestions and ideas on how to improve.

### Changes
- Added Reels as a blockable option
- Added Feeds button to top bar
- Added Settings Toggle button to top bar (which categories should be blocked)
- Made menu bar sticky to mirror FB official app
- Removed GM_addStyle line
  - This acutally broke all overlay menus on the current version, I realize it was to try to remove the FB app banner which nags you to install but it seems to be too aggressive.
- Removed setFillerHeight, it was just commented at the moment so I took it out while linting...not sure if it will be needed in the futuer

### Screenshots
![image](https://github.com/user-attachments/assets/167bb43f-c41d-4098-8a66-ad2b29b972a1)
![image](https://github.com/user-attachments/assets/5a952254-4828-48df-8f2e-74397fc5a2f4)
